### PR TITLE
Add mooc-grader to repos using string keys

### DIFF
--- a/contribute/styleguides/gettext/index.md
+++ b/contribute/styleguides/gettext/index.md
@@ -9,7 +9,7 @@ The idea is not to update fields that do not add any value and fields that are n
 
 * **What the message ID should be:**
 
-  * In the [a-plus repository](https://github.com/apluslms/a-plus), separate message keys are used in the Django translations.
+  * In the [a-plus](https://github.com/apluslms/a-plus) and [mooc-grader](https://github.com/apluslms/mooc-grader) repositories, separate message keys are used in the Django translations.
     Translations are written for each language (including English) in the corresponding `.po` files.
     See section [msdID format](#msgid-format) for more details.
   * In other repositories (at least at the moment), use the English string as the message ID (i.e. default string) and make translations for other languages (e.g. Finnish).
@@ -36,7 +36,7 @@ The idea is not to update fields that do not add any value and fields that are n
 
 ### msgID format
 
-**NOTE:** This is currently in use only in the [a-plus repository](https://github.com/apluslms/a-plus).
+**NOTE:** This is currently in use only in the [a-plus](https://github.com/apluslms/a-plus) and [mooc-grader](https://github.com/apluslms/mooc-grader) repositories.
 
 In order to make editing strings displayed to users easier (and less likely to break things), rather than using the English string as the message ID, a separate key is used as a message ID.
 


### PR DESCRIPTION
# Description

**What?**

Document in the gettext styleguide that now mooc-grader uses string keys with translations in addition to the a-plus repository.

**Why?**

In order for documentation to be up to date.

**How?**

By updating the documentation


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [x] Other test. *(Add a description below)*
- [ ] Manual testing.

I checked that the page looks fine in my own fork

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature