### PR TITLE
Add a self-entry to the list of authors

### DIFF
--- a/about/authors/index.md
+++ b/about/authors/index.md
@@ -116,6 +116,7 @@ Past core team members:
 * [Ville Karavirta](https://github.com/vkaravir)
 * [Ville V](https://github.com/Vilz92)
 * Yusein Ali
+* [Ziqi Wang (王子祺)](https://github.com/James-Leste)
 
 [end-of-contributors]: # (End of automatically updated list)
 


### PR DESCRIPTION
Wish you are doing well! 

I wish to add my name to the list of authors, thank you! Considering my first name starts with **"Z"**, I assume it should appear at the end of the current list

Name: Ziqi Wang (王子祺)
Authored Commits:
- https://github.com/apluslms/a-plus/commit/35fef98f112cc0f6d24e8bca26e6eaa4a2fc9444
- https://github.com/apluslms/a-plus/commit/6d0e947cdc40786cf1f85ebcb0caef1a5d4e982d
- https://github.com/apluslms/a-plus/commit/2df61cd56d447ec750883e639e136317d337a9b1
- https://github.com/apluslms/a-plus/commit/5dad40da7bfcf78008114803f97d2094e5fafd68
